### PR TITLE
Compare map wrapper

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,7 @@
 {
   "extends": ["standard", "standard-preact"],
   "rules": {
-    "jsx-quotes": ["error", "prefer-double"]
+    "jsx-quotes": ["error", "prefer-double"],
+    "max-len": ["error", 120]
   }
 }

--- a/public/app.js
+++ b/public/app.js
@@ -3,8 +3,8 @@ const { ODRI, fetch, process } = window
 function mountViz (data) {
   ODRI.activity('#activity', { width: '670px', data })
   ODRI.compareMap('#compare-map', {
-    width: '670px',
-    height: '670px',
+    width: '100%',
+    height: '500px',
     settings: {}
   })
   ODRI.topContributors('#top-contributors', { width: '300px', data })

--- a/public/app.js
+++ b/public/app.js
@@ -5,7 +5,9 @@ function mountViz (data) {
   ODRI.compareMap('#compare-map', {
     width: '100%',
     height: '500px',
-    settings: {}
+    settings: {
+      defaultFeatureType: 'highways'
+    }
   })
   ODRI.topContributors('#top-contributors', { width: '300px', data })
 }

--- a/public/app.js
+++ b/public/app.js
@@ -2,6 +2,11 @@ const { ODRI, fetch, process } = window
 
 function mountViz (data) {
   ODRI.activity('#activity', { width: '670px', data })
+  ODRI.compareMap('#compare-map', {
+    width: '670px',
+    height: '670px',
+    settings: {}
+  })
   ODRI.topContributors('#top-contributors', { width: '300px', data })
 }
 

--- a/public/index.html
+++ b/public/index.html
@@ -26,7 +26,7 @@
           <h2>Understanding Haiti’s Risks</h2>
           <p>Haiti’s development challenges are compounded by repeated and devastating impacts of natural disasters. Hurricanes and tropical storms routinely strike Haiti, causing massive flooding and deadly landslides. In January 2010, an unprecedented earthquake of magnitude 7.0 decimated Port-auPrince, affecting 3.5 million and leaving more than 200,000 dead. Furthermore, growth pressure has led to extreme environmental degradation, with an estimated 98% of forests cleared for charcoal production. These destabilizing forces, as well as settlement in zones with high levels of natural hazard and poor construction practices, have left most Haitians extremely vulnerable to natural disasters.</p>
 
-          <div id="OSMA"></div>
+          <div id="compare-map"></div>
 
           <h2>Sharing Data</h2>
           <p>The Open Data for Resilience Initiative supports the <a href="http://www.haitidata.org/" target="_blank">HaitiData GeoNode</a> for disaster risk management. The purpose of this site is to facilitate open access to Haiti-related geo-spatial information, data and knowledge sources, encouraging others to share and use them for the development of Haiti.</p>

--- a/src/compare-map/compare-map.jsx
+++ b/src/compare-map/compare-map.jsx
@@ -5,7 +5,11 @@ import { COMPARE_MAP_DEFAULTS } from 'src/constants'
 
 const CompareMap = ({ width, height, settings }) => {
   const finalSettings = Object.assign(COMPARE_MAP_DEFAULTS, settings)
-  const iframeUrl = `${finalSettings.iframeBaseUrl}/#/compare/polygon:${finalSettings.polygon}/${finalSettings.defaultStartYear}...${finalSettings.defaultEndYear}/${finalSettings.defaultFeatureType}/embed`
+  const iframeUrl = `${finalSettings.iframeBaseUrl}/#/compare
+  /polygon:${finalSettings.polygon}
+  /${finalSettings.defaultStartYear}...${finalSettings.defaultEndYear}
+  /${finalSettings.defaultFeatureType}
+  /embed`
 
   return (
     <iframe

--- a/src/compare-map/compare-map.jsx
+++ b/src/compare-map/compare-map.jsx
@@ -1,17 +1,17 @@
 import { h } from 'preact'
-// import cx from 'classnames'
 
 import { mountComponent } from 'utils'
-// import appStyles from 'styles.scss'
-// import styles from './top-contributors.scss'
+import { COMPARE_MAP_DEFAULTS } from 'src/constants'
 
-const CompareMap = ({ width, height }) => {
-  console.log(width, height)
+const CompareMap = ({ width, height, settings }) => {
+  const finalSettings = Object.assign(COMPARE_MAP_DEFAULTS, settings)
+  const iframeUrl = `${finalSettings.iframeBaseUrl}/#/compare/polygon:${finalSettings.polygon}/${finalSettings.defaultStartYear}...${finalSettings.defaultEndYear}/${finalSettings.defaultFeatureType}/embed`
+
   return (
     <iframe
       scrolling="no"
       style={{ width, height, border: 0 }}
-      src="http://localhost:3000/#/compare/polygon:ifv%7BDndwkBx%60%40aYwQev%40sHkPuf%40ss%40%7BfA_%40uq%40xdCn%7D%40%5E/2010...now/buildings/embed"
+      src={iframeUrl}
     />
   )
 }

--- a/src/compare-map/compare-map.jsx
+++ b/src/compare-map/compare-map.jsx
@@ -1,0 +1,20 @@
+import { h } from 'preact'
+// import cx from 'classnames'
+
+import { mountComponent } from 'utils'
+// import appStyles from 'styles.scss'
+// import styles from './top-contributors.scss'
+
+const CompareMap = ({ width, height }) => {
+  console.log(width, height)
+  return (
+    <iframe
+      style={{ width, height }}
+      src="http://localhost:3000/#/compare/polygon:ifv%7BDndwkBx%60%40aYwQev%40sHkPuf%40ss%40%7BfA_%40uq%40xdCn%7D%40%5E/2010...now/buildings/embed"
+    />
+  )
+}
+
+export default function topContributors (selector, options) {
+  return mountComponent(CompareMap, selector, options)
+}

--- a/src/compare-map/compare-map.jsx
+++ b/src/compare-map/compare-map.jsx
@@ -9,7 +9,8 @@ const CompareMap = ({ width, height }) => {
   console.log(width, height)
   return (
     <iframe
-      style={{ width, height }}
+      scrolling="no"
+      style={{ width, height, border: 0 }}
       src="http://localhost:3000/#/compare/polygon:ifv%7BDndwkBx%60%40aYwQev%40sHkPuf%40ss%40%7BfA_%40uq%40xdCn%7D%40%5E/2010...now/buildings/embed"
     />
   )

--- a/src/constants.js
+++ b/src/constants.js
@@ -23,3 +23,12 @@ export const GRANULARITIES = {
   w: 'Weekly',
   m: 'Monthly'
 }
+
+export const COMPARE_MAP_DEFAULTS = {
+  iframeBaseUrl: 'http://localhost:3000',
+  polygon:
+    'ifv%7BDndwkBx%60%40aYwQev%40sHkPuf%40ss%40%7BfA_%40uq%40xdCn%7D%40%5E',
+  defaultStartYear: '2010',
+  defaultEndYear: 'now',
+  defaultFeatureType: 'buildings'
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,8 @@
 import activity from './activity'
+import compareMap from './compare-map'
 import topContributors from './top-contributors'
 
 require('es6-promise').polyfill()
 require('isomorphic-fetch')
 
-export {
-  activity,
-  topContributors
-}
+export { activity, compareMap, topContributors }


### PR DESCRIPTION
![screen shot 2017-06-27 at 14 32 26](https://user-images.githubusercontent.com/1583415/27588576-f3afcfb4-5b48-11e7-949a-b4bc92db1794.png)

Adds a lightweight iframe component wrapping the OSMA client. 
Example above runs with a the OSMA client (still unstyled) running locally (use this branch https://github.com/GFDRR/osm-analytics/pull/7/files)

Component is configurable using options described here https://github.com/Vizzuality/opendri-charts/pull/20/files

